### PR TITLE
perf:avoid removing all components on insert to improve performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-gridlayout-root</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>vcf-gridlayout</module>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>GridLayout for Flow</description>
 
     <properties>
-        <vaadin.version>14.7.7</vaadin.version>
+        <vaadin.version>14.10.11</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-gridlayout-demo/pom.xml
+++ b/vcf-gridlayout-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-gridlayout-demo</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
 
     <name>GridLayout Demo</name>
     <packaging>war</packaging>

--- a/vcf-gridlayout-demo/pom.xml
+++ b/vcf-gridlayout-demo/pom.xml
@@ -18,8 +18,8 @@
     </organization>
 
     <properties>
-        <vaadin.version>14.7.7</vaadin.version>
-        <flow.version>2.7.6</flow.version>
+        <vaadin.version>14.10.11</vaadin.version>
+        <flow.version>2.9.11</flow.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-gridlayout/pom.xml
+++ b/vcf-gridlayout/pom.xml
@@ -19,7 +19,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>14.7.7</vaadin.version>
+        <vaadin.version>14.10.11</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-gridlayout/pom.xml
+++ b/vcf-gridlayout/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-gridlayout</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>GridLayout</name>

--- a/vcf-gridlayout/src/main/java/com/vaadin/componentfactory/gridlayout/GridLayout.java
+++ b/vcf-gridlayout/src/main/java/com/vaadin/componentfactory/gridlayout/GridLayout.java
@@ -317,33 +317,34 @@ public class GridLayout extends Composite<Div> implements HasSize, HasStyle {
     // Checks that newItem does not overlap with existing items
     checkExistingOverlaps(area);
 
-    // Inserts the component to right place at the list
-    // Respect top-down, left-right ordering
-    final Iterator<Component> i = components.iterator();
-    component = wrapComponent(component);
-    int index = 0;
-    boolean done = false;
-    while (!done && i.hasNext()) {
-      final ChildComponentData existingArea = componentsDataMap.get(i.next());
-      if ((existingArea.row1 >= row1 && existingArea.column1 > column1)
-          || existingArea.row1 > row1) {
-        components.add(index, component);
-        setComponentArea(component, column1, row1, column2, row2);
-        done = true;
-      }
-      index++;
-    }
-    if (!done) {
-      components.addLast(component);
-      setComponentArea(component, column1, row1, column2, row2);
-    }
-
-    componentsDataMap.put(component, new ChildComponentData(column1, row1, column2, row2));
-
-    // Attempt to add to div
     try {
-      div.removeAll();
-      div.add(components.toArray(new Component[0]));
+      // Inserts the component to right place at the list
+      // Respect top-down, left-right ordering
+      final Iterator<Component> i = components.iterator();
+      component = wrapComponent(component);
+      int index = 0;
+      boolean done = false;
+      while (!done && i.hasNext()) {
+        final ChildComponentData existingArea = componentsDataMap.get(i.next());
+        if ((existingArea.row1 >= row1 && existingArea.column1 > column1)
+            || existingArea.row1 > row1) {
+          components.add(index, component);
+          setComponentArea(component, column1, row1, column2, row2);
+          done = true;
+          // add to div
+          div.getElement().insertChild(index, component.getElement());
+        }
+        index++;
+      }
+      if (!done) {
+        components.addLast(component);
+        setComponentArea(component, column1, row1, column2, row2);
+        // add to div
+        div.getElement().appendChild(component.getElement());
+      }
+  
+      componentsDataMap.put(component, new ChildComponentData(column1, row1, column2, row2));
+      
     } catch (IllegalArgumentException e) {
       components.remove(component);
       componentsDataMap.remove(component);


### PR DESCRIPTION
Close #7

In order to improve performance, this fix contemplates adding each component to the containing div on each "addComponent" call which eliminates the necessity for the "div.removeAll" call.